### PR TITLE
Fix: Preserve playback time when dragging song nodes on canvas

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -228,6 +228,7 @@ function FlowContent({ nodes, edges, setNodes, setEdges, onNodesChange, onEdgesC
         nodesConnectable={false}
         edgesUpdatable={false}
         connectOnClick={false}
+        panOnDrag={[2]}
         defaultViewport={{ x: 0, y: 0, zoom: 1.2 }}
         minZoom={0.8}
         maxZoom={2}

--- a/frontend/src/components/MusicPlayer.js
+++ b/frontend/src/components/MusicPlayer.js
@@ -325,12 +325,19 @@ const MusicPlayer = ({ songQueue, currentSong, setCurrentSong, nodes, edges, set
     };
   }, [currentSongIndex, songQueue, setCurrentSong, isPlayingTransition, setTransitioningEdgeId]);
 
+  // Track the previous song ID to detect actual song changes
+  const prevSongIdRef = useRef(null);
+
   // Handle song changes
   useEffect(() => {
     const audio = audioRef.current;
     if (!audio) return;
 
-    if (currentSong) {
+    const currentSongId = currentSong?.id;
+    const songActuallyChanged = currentSongId !== prevSongIdRef.current;
+
+    if (currentSong && songActuallyChanged) {
+      // Only reload audio when the song actually changes
       audio.src = currentSong.audioFile;
       audio.load();
 
@@ -340,12 +347,16 @@ const MusicPlayer = ({ songQueue, currentSong, setCurrentSong, nodes, edges, set
       setIsPlayingTransition(false);
       setTransitioningEdgeId(null);
 
+      // Update the previous song ID
+      prevSongIdRef.current = currentSongId;
+
       // Find index in queue
       const index = songQueue.findIndex(item => item.song.id === currentSong.id);
       if (index !== -1) {
         setCurrentSongIndex(index);
       }
-    } else {
+    } else if (!currentSong && prevSongIdRef.current !== null) {
+      // Only reset when going from a song to no song
       audio.pause();
       audio.src = '';
       setIsPlaying(false);
@@ -353,6 +364,7 @@ const MusicPlayer = ({ songQueue, currentSong, setCurrentSong, nodes, edges, set
       setDuration(0);
       setIsPlayingTransition(false);
       setTransitioningEdgeId(null);
+      prevSongIdRef.current = null;
     }
   }, [currentSong, songQueue, setTransitioningEdgeId]);
 


### PR DESCRIPTION
When dragging a song node, the songQueue was being recalculated which triggered the MusicPlayer useEffect to reload the audio and reset playback to the beginning.

Now the MusicPlayer only reloads audio when the song ID actually changes, not when the queue reference changes. This preserves the current playback time and position when moving nodes around on the canvas.
